### PR TITLE
Allow node-fetch to work with configured proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   "dependencies": {
     "@types/chalk": "^0.4.31",
     "@types/graphql": "^0.8.6",
+    "@types/http-proxy-agent": "^2.0.0",
     "@types/minimist": "^1.2.0",
     "@types/node": "^7.0.4",
     "@types/node-fetch": "^1.6.7",
     "chalk": "^1.1.3",
     "graphql": "^0.9.1",
+    "https-proxy-agent": "^2.2.0",
     "minimist": "^1.2.0",
     "node-fetch": "^1.6.3"
   },

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,0 +1,14 @@
+import fetch from 'node-fetch';
+import * as HttpsProxyAgent from 'https-proxy-agent';
+
+export default (url: string, options) => {
+    const instanceOptions = {
+        ...options
+    };
+
+    if (!options.agent && process.env.HTTP_PROXY) {
+        instanceOptions.agent = new HttpsProxyAgent(process.env.HTTP_PROXY);
+    }
+
+    return fetch(url, instanceOptions);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import fetch from 'node-fetch'
+import fetch from './fetch'
 import { introspectionQuery } from 'graphql/utilities/introspectionQuery'
 import { buildClientSchema } from 'graphql/utilities/buildClientSchema'
 import { printSchema } from 'graphql/utilities/schemaPrinter'


### PR DESCRIPTION
I'm on a network which requires HTTP proxy to connect with the outside world and unfortunately `get-graphql-schema` is not working.

This PR allows the underlying `node-fetch` to work through a proxy if it has been configured. Related: https://github.com/bitinn/node-fetch/issues/195

cc @dezzak