### PR TITLE
Split headers on colon to support cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install -g get-graphql-schema
   (Outputs schema in IDL syntax by default)
 
   Options:
-    --header, -h    Add a custom header (ex. 'X-API-KEY=ABC123'), can be used multiple times
+    --header, -h    Add a custom header (ex. 'X-API-KEY: ABC123', 'Cookie: biscuit=123'), can be used multiple times
     --json, -j      Output in JSON format (based on introspection query)
     --version, -v   Print version of get-graphql-schema
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ async function main() {
   const headers = toArray(argv['header'])
     .concat(toArray(argv['h']))
     .reduce((obj, header: string) => {
-      const [key, value] = header.split('=')
+      const [key, value] = header.split(':')
       obj[key] = value
       return obj
     }, defaultHeaders)


### PR DESCRIPTION
Adds support for Cookie headers.

So, this example would now work:
```bash
get-graphql-schema --header "Cookie: biscuit=123" ENDPOINT_URL > schema.graphql
```

This previously would not work as the header string was split on `=` which is found in the actual value of the cookie.

Now the header string is split on `:`, which is a common convention in other tools.
