### PR TITLE
import utilities from the correct path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,11 @@ import * as fs from 'fs'
 import * as path from 'path'
 import meow = require('meow')
 import mkdirp = require('mkdirp')
-import { introspectionQuery } from 'graphql/utilities/introspectionQuery'
-import { buildClientSchema } from 'graphql/utilities/buildClientSchema'
-import { printSchema } from 'graphql/utilities/schemaPrinter'
+import {
+  buildClientSchema,
+  printSchema,
+  getIntrospectionQuery,
+} from 'graphql/utilities'
 import * as query from 'querystringify'
 
 /**
@@ -59,7 +61,7 @@ export async function getRemoteSchema(
     const { data, errors } = await fetch(endpoint, {
       method: options.method,
       headers: options.headers,
-      body: JSON.stringify({ query: introspectionQuery }),
+      body: JSON.stringify({ query: getIntrospectionQuery() }),
     }).then(res => res.json())
 
     if (errors) {


### PR DESCRIPTION
See documentation: https://graphql.org/graphql-js/utilities/

With GraphQL 15 the import path's have changed. According to the docs the things should be imported from `graphql-js/utilities`.

I also needed to change `introspectionQuery` to `getIntrospectionQuery` as only the latter was in the type definitions. Otherwise the tests would fail because it would not compile.

