### PR TITLE
feature: add --allowInsecure command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ npm install -g get-graphql-schema
   Options:
     --header, -h    Add a custom header (ex. 'X-API-KEY=ABC123'), can be used multiple times
     --json, -j      Output in JSON format (based on introspection query)
-    --version, -v   Print version of get-graphql-schema
-
+    --method        Use method (GET,POST, PUT, DELETE)
+    --output       Save schema to file
+    --allowInsecure, -k  Ignore invalid and self-signed certificate checks.
 ```
 
 ## Help & Community [![Slack Status](https://slack.graph.cool/badge.svg)](https://slack.graph.cool)

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -14,7 +14,8 @@ Options:
   --header, -h    Add a custom header (ex. 'X-API-KEY=ABC123'), can be used multiple times
   --json, -j      Output in JSON format (based on introspection query)
   --method        Use method (GET,POST, PUT, DELETE)
-  --output       Save schema to file.
+  --output       Save schema to file
+  --allowInsecure, -k  Ignore invalid and self-signed certificate checks.
 `,
   {
     flags: {
@@ -33,6 +34,10 @@ Options:
       },
       output: {
         type: 'string',
+      },
+      allowInsecure: {
+        type: 'boolean',
+        alias: 'k',
       },
     },
   },
@@ -68,6 +73,7 @@ export async function main(cli: meow.Result): Promise<void> {
     method: cli.flags.method,
     headers,
     json: cli.flags.json,
+    allowInsecure: cli.flags.allowInsecure,
   })
 
   if (schema.status === 'err') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch'
+import * as https from 'https';
 import * as fs from 'fs'
 import * as path from 'path'
 import meow = require('meow')
@@ -40,6 +41,7 @@ interface Options {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
   headers?: { [key: string]: string }
   json?: boolean
+  allowInsecure: boolean
 }
 
 /**
@@ -56,7 +58,12 @@ export async function getRemoteSchema(
   { status: 'ok'; schema: string } | { status: 'err'; message: string }
 > {
   try {
+    const agent = new https.Agent({
+      rejectUnauthorized: !options.allowInsecure,
+    });
+
     const { data, errors } = await fetch(endpoint, {
+      agent,
       method: options.method,
       headers: options.headers,
       body: JSON.stringify({ query: introspectionQuery }),


### PR DESCRIPTION
To ignore invalid and self-signed certificate checks one can pass the `--allowInsecure` (or `-k`) command line argument.